### PR TITLE
ci: Add explicit pipeline permissions to CI workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 23 * * 5'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyse:
     name: Analyse

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   IMAGE: sierrasoftworks/vue-template
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SierraSoftworks/vue-template/security/code-scanning/17](https://github.com/SierraSoftworks/vue-template/security/code-scanning/17)

Add an explicit `permissions` block to `.github/workflows/codeql-analysis.yml` so the workflow does not rely on repository/org defaults.

Best single fix without changing functionality:
- Define workflow-level permissions right after the `on:` block (before `jobs:`).
- Set:
  - `contents: read` (required for checkout and repo read operations)
  - `security-events: write` (required for uploading CodeQL analysis results)

This keeps least privilege while preserving expected CodeQL behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
